### PR TITLE
Fix tests for Stryker run

### DIFF
--- a/tests/CalculatorLib.Tests/CalculatorTests.cs
+++ b/tests/CalculatorLib.Tests/CalculatorTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using CalculatorLib;
+using System;
 
 namespace CalculatorLib.Tests
 {


### PR DESCRIPTION
## Summary
- fix compile error in tests by importing System namespace
- run Stryker mutation tests to check coverage

## Testing
- `dotnet build CalculatorExample.sln`
- `dotnet test CalculatorExample.sln --no-build`
- `dotnet-stryker --msbuild-path /usr/bin/dotnet`
